### PR TITLE
Add Script to Restart Docker Containers on Existing Tenant EC2 Instances After New Version Published

### DIFF
--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -10,7 +10,7 @@ REPO_ROOT_DIR=$(pwd)
 echo "Repo root directory: $REPO_ROOT_DIR"
 
 # Services to update
-SERVICES=("accounts" "chat" "datalake")
+SERVICES=("accounts" "cdatalakeat" "chat")
 
 echo "Services to process: ${SERVICES[*]}"
 
@@ -63,9 +63,16 @@ echo "Docker cleanup completed."
 echo ""
 echo "===== Restarting nginx container ====="
 
-if sudo docker ps --format '{{.Names}}' | grep -q "^nginx$"; then
-    echo "Found nginx container. Restarting..."
-    sudo docker restart nginx && echo "nginx restarted successfully."
+# Find nginx container by name pattern
+NGINX_CONTAINER=$(sudo docker ps --format '{{.Names}}' | grep -i 'nginx' || true)
+
+if [ -n "$NGINX_CONTAINER" ]; then
+    echo "Found nginx container: $NGINX_CONTAINER"
+    if sudo docker restart "$NGINX_CONTAINER"; then
+        echo "nginx restarted successfully."
+    else
+        echo "WARNING: Failed to restart nginx container."
+    fi
 else
     echo "WARNING: nginx container not found. Skipping restart."
 fi

--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -9,16 +9,12 @@ echo "====================================================="
 REPO_ROOT_DIR=$(pwd)
 echo "Repo root directory: $REPO_ROOT_DIR"
 
-# ---------------------------------------
 # Services to update
-# ---------------------------------------
 SERVICES=("accounts" "chat" "datalake")
 
 echo "Services to process: ${SERVICES[*]}"
 
-# ---------------------------------------
 # Docker updates
-# ---------------------------------------
 echo ""
 echo "===== Starting Docker Update Process ====="
 
@@ -57,13 +53,22 @@ done
 echo ""
 echo "===== Docker Update Process Completed ====="
 
-# ---------------------------------------
 # Cleanup
-# ---------------------------------------
 echo ""
 echo "===== Cleaning Docker System ====="
 sudo docker system prune -f
 echo "Docker cleanup completed."
+
+# Restart nginx
+echo ""
+echo "===== Restarting nginx container ====="
+
+if sudo docker ps --format '{{.Names}}' | grep -q "^nginx$"; then
+    echo "Found nginx container. Restarting..."
+    sudo docker restart nginx && echo "nginx restarted successfully."
+else
+    echo "WARNING: nginx container not found. Skipping restart."
+fi
 
 echo ""
 echo "====================================================="

--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -6,7 +6,7 @@ echo "    LayerNext Tenant Release Publisher"
 echo "    (publish-existing-tenant-release.sh)"
 echo "====================================================="
 
-REPO_ROOT_DIR=$(pwd)
+REPO_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Repo root directory: $REPO_ROOT_DIR"
 
 # ---------------------------------------
@@ -50,7 +50,7 @@ for service in "${SERVICES[@]}"; do
 
         cd "$REPO_ROOT_DIR"
     else
-        echo "Skipping '$service' — directory not found."
+        echo "Skipping '$service' - directory not found."
     fi
 done
 

--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "====================================================="
+echo "    LayerNext Tenant Release Publisher"
+echo "    (publish-existing-tenant-release.sh)"
+echo "====================================================="
+
+REPO_ROOT_DIR=$(pwd)
+echo "Repo root directory: $REPO_ROOT_DIR"
+
+# ---------------------------------------
+# Services to update
+# ---------------------------------------
+SERVICES=("accounts" "chat" "datalake")
+
+echo "Services to process: ${SERVICES[*]}"
+
+# ---------------------------------------
+# Docker updates
+# ---------------------------------------
+echo ""
+echo "===== Starting Docker Update Process ====="
+
+for service in "${SERVICES[@]}"; do
+    SERVICE_PATH="$REPO_ROOT_DIR/$service"
+
+    if [ -d "$SERVICE_PATH" ]; then
+        echo ""
+        echo "-------------------------------------------"
+        echo "Processing service: $service"
+        echo "Path: $SERVICE_PATH"
+        echo "-------------------------------------------"
+
+        cd "$SERVICE_PATH"
+
+        echo "Pulling images for $service..."
+        if sudo docker compose pull; then
+            echo "Pull completed successfully."
+        else
+            echo "WARNING: Failed to pull images for $service"
+        fi
+
+        echo "Recreating containers for $service..."
+        if sudo docker compose up -d --force-recreate; then
+            echo "Service $service updated successfully."
+        else
+            echo "WARNING: Failed to recreate $service containers"
+        fi
+
+        cd "$REPO_ROOT_DIR"
+    else
+        echo "Skipping '$service' — directory not found."
+    fi
+done
+
+echo ""
+echo "===== Docker Update Process Completed ====="
+
+# ---------------------------------------
+# Cleanup
+# ---------------------------------------
+echo ""
+echo "===== Cleaning Docker System ====="
+sudo docker system prune -f
+echo "Docker cleanup completed."
+
+echo ""
+echo "====================================================="
+echo "         Tenant Release Publishing Complete"
+echo "====================================================="

--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -6,7 +6,7 @@ echo "    LayerNext Tenant Release Publisher"
 echo "    (publish-existing-tenant-release.sh)"
 echo "====================================================="
 
-REPO_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT_DIR=$(pwd)
 echo "Repo root directory: $REPO_ROOT_DIR"
 
 # ---------------------------------------
@@ -50,7 +50,7 @@ for service in "${SERVICES[@]}"; do
 
         cd "$REPO_ROOT_DIR"
     else
-        echo "Skipping '$service' - directory not found."
+        echo "Skipping '$service' — directory not found."
     fi
 done
 

--- a/scripts/publish-existing-tenant-release.sh
+++ b/scripts/publish-existing-tenant-release.sh
@@ -10,7 +10,7 @@ REPO_ROOT_DIR=$(pwd)
 echo "Repo root directory: $REPO_ROOT_DIR"
 
 # Services to update
-SERVICES=("accounts" "cdatalakeat" "chat")
+SERVICES=("accounts" "datalake" "chat")
 
 echo "Services to process: ${SERVICES[*]}"
 


### PR DESCRIPTION
### Summary
This PR introduces a new script (`publish-existing-tenant-release.sh`) that automates updating and restarting Docker-based services on existing tenant EC2 instances.

### What the Script Does
- Detects and processes the following tenant services:
  - `accounts`
  - `datalake`
  - `chat`
- Pulls the latest Docker images for each service.
- Recreates and restarts containers using `docker compose up -d --force-recreate`.
- Cleans up unused Docker resources with `docker system prune -f`.
- Automatically detects and restarts the running **nginx** container to ensure networking and routing work correctly after updates.
